### PR TITLE
refactor(calendar): normalize foreign key references for consistency

### DIFF
--- a/banking-api/src/domain/calendar.rs
+++ b/banking-api/src/domain/calendar.rs
@@ -12,7 +12,7 @@ pub struct BankHoliday {
     pub holiday_type: HolidayType,
     pub is_recurring: bool,
     pub description: Option<HeaplessString<200>>,
-    /// References Person.person_id
+    /// References Person.id
     pub created_by_person_id: Uuid,
     pub created_at: DateTime<Utc>,
 }

--- a/banking-db-postgres/migrations/001_initial_schema.sql
+++ b/banking-db-postgres/migrations/001_initial_schema.sql
@@ -1248,7 +1248,7 @@ CREATE TABLE holiday_import_log (
     holidays_skipped INTEGER NOT NULL DEFAULT 0,
     import_status import_status NOT NULL,
     error_details VARCHAR(1000),
-    imported_by UUID NOT NULL REFERENCES persons(id),
+    imported_by_person_id UUID NOT NULL REFERENCES persons(id),
     imported_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 

--- a/banking-db/src/models/calendar.rs
+++ b/banking-db/src/models/calendar.rs
@@ -50,7 +50,7 @@ pub struct BankHolidayModel {
     pub holiday_type: HolidayType, // Use enum instead of HeaplessString
     pub is_recurring: bool,   // Annual recurrence flag
     pub description: Option<HeaplessString<200>>, // Updated to match API domain
-    pub created_by_person_id: Uuid, // References Person.person_id
+    pub created_by_person_id: Uuid, // References Person.id
     pub created_at: DateTime<Utc>,
 }
 
@@ -65,9 +65,9 @@ pub struct WeekendConfigurationModel {
     pub is_active: bool,
     pub notes: Option<HeaplessString<256>>,
     pub created_at: DateTime<Utc>,
-    pub created_by_person_id: Uuid, // References Person.person_id
+    pub created_by_person_id: Uuid, // References Person.id
     pub last_updated_at: DateTime<Utc>,
-    pub updated_by_person_id: Uuid, // References Person.person_id
+    pub updated_by_person_id: Uuid, // References Person.id
 }
 
 /// Date Calculation Rules database model
@@ -86,9 +86,9 @@ pub struct DateCalculationRulesModel {
     pub effective_date: NaiveDate,
     pub expiry_date: Option<NaiveDate>,
     pub created_at: DateTime<Utc>,
-    pub created_by_person_id: Uuid, // References Person.person_id
+    pub created_by_person_id: Uuid, // References Person.id
     pub last_updated_at: DateTime<Utc>,
-    pub updated_by_person_id: Uuid, // References Person.person_id
+    pub updated_by_person_id: Uuid, // References Person.id
 }
 
 /// Holiday Import Log database model (for audit trail of holiday imports)
@@ -104,7 +104,7 @@ pub struct HolidayImportLogModel {
     pub holidays_skipped: i32,
     pub import_status: ImportStatus, // Use enum instead of HeaplessString
     pub error_details: Option<HeaplessString<1000>>,
-    pub imported_by: Uuid, // References Person.person_id
+    pub imported_by_person_id: Uuid, // References Person.id
     pub imported_at: DateTime<Utc>,
 }
 

--- a/prompts/foreign-key-ref-alignment.md
+++ b/prompts/foreign-key-ref-alignment.md
@@ -21,10 +21,15 @@ For fields with compound qualifiers that don't have individual target structs:
 - `transaction_reason_id: Option<Uuid>` → **KEEP AS IS** (target: `ReasonAndPurpose`, no `Reason` struct exists)
 
 ### 4. Person Reference Pattern
-All `*_by` fields reference `Person`:
-- `created_by_person_id: Uuid` → `created_by_person_id: Uuid`
-- `updated_by_person_id: Uuid` → `updated_by_person_id: Uuid`
+All `*_by` fields reference `Person` and should include explicit `_person_id` suffix:
+- `created_by_person_id: Uuid` → **KEEP AS IS** (already follows correct pattern)
+- `updated_by_person_id: Uuid` → **KEEP AS IS** (already follows correct pattern)
 - `approved_by: Option<Uuid>` → `approved_by_person_id: Option<Uuid>`
+
+### 5. Preserve Existing Correct Patterns
+Fields that already follow the explicit entity reference pattern should not be modified:
+- If field already includes target entity name (e.g., `created_by_person_id`, `updated_by_person_id`), keep unchanged
+- Only modify fields that lack explicit entity reference (e.g., `approved_by` → `approved_by_person_id`, `imported_by` → `imported_by_person_id`)
 
 ## Workflow Steps
 


### PR DESCRIPTION
Normalize foreign key field naming in calendar domain to follow consistent pattern:
- imported_by → imported_by_person_id (explicit Person entity reference)
- Preserve existing correct patterns: created_by_person_id, updated_by_person_id

Components affected:
- Domain Model: Updated BankHoliday comment to reference Person.id
- Database Model: Changed imported_by to imported_by_person_id in HolidayImportLogModel
- Database Schema: Updated holiday_import_log table column name
- Workflow Documentation: Added rule #5 to preserve existing correct patterns

Benefits:
- Consistent foreign key naming across calendar domain
- Explicit entity references improve code readability
- Alignment with established normalization patterns from other domains
- Enhanced developer experience with predictable field naming

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
Signed-off-by: Francis Pouatcha <francis.pouatcha@adorsys.com>